### PR TITLE
prEvent_IsRest final speed optimizations

### DIFF
--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -49,12 +49,7 @@ Event : Environment {
 
 	isRest {
 		_Event_IsRest
-		^this[\type] == \rest or: {
-			this.use {
-				parent ?? { parent = defaultParentEvent };
-				~detunedFreq.value.isRest
-			}
-		}
+		^this[\type] == \rest
 	}
 
 	// node watcher interface

--- a/SCClassLibrary/Common/Collections/Event.sc
+++ b/SCClassLibrary/Common/Collections/Event.sc
@@ -49,7 +49,7 @@ Event : Environment {
 
 	isRest {
 		_Event_IsRest
-		^this[\type] == \rest
+		^false
 	}
 
 	// node watcher interface

--- a/lang/LangPrimSource/PyrListPrim.cpp
+++ b/lang/LangPrimSource/PyrListPrim.cpp
@@ -568,6 +568,9 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 		PyrClass *restMetaClass = getsym("Meta_Rest")->u.classobj;
 		PyrObject *array = slotRawObject(arraySlot);
 		PyrSlot *slot = array->slots + 1;  // scan only the odd items
+		PyrSymbol *emptySym = getsym("");
+		PyrSymbol *rSym = getsym("r");
+		PyrSymbol *slotSym;
 		int32 size = array->size;
 		int32 i;
 
@@ -575,6 +578,15 @@ int prEvent_IsRest(struct VMGlobals *g, int numArgsPushed)
 			if (isKindOfSlot(slot, restClass) || isKindOfSlot(slot, restMetaClass)) {
 				SetBool(g->sp, 1);
 				return errNone;
+			} else {
+				// slotSymbolVal nonzero return = not a symbol;
+				// non-symbols don't indicate rests, so, ignore them.
+				if(!slotSymbolVal(slot, &slotSym)) {
+					if(slotSym == emptySym || slotSym == rSym) {
+						SetBool(g->sp, 1);
+						return errNone;
+					}
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Per discussion under https://github.com/supercollider/supercollider/pull/2802, these are the last(?) speed improvements for the isRest primitive. Submitting this way for review. One thing I'm not sure about: proper formatting for some lengthy `if` conditions: `if(slotSym == s_empty || slotSym == s_r || slotSym == s_rest)` -- with tab indentation, it goes quite far to the right.

I've tested according to the spec in 2802, seems OK.
						